### PR TITLE
fix: expose yarn peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "contributors": [
     "Romain Beauxis <toots@rastageeks.org>",
     "James Halliday <mail@substack.net>",
-    "Takuya Matsuyama <hi@craftz.dog>"
+    "Takuya Matsuyama <hi@craftz.dog>",
+    "Vicary Archangel <vicary.archangel@member.mensa.org>"
   ],
   "dependencies": {
     "ieee754": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "through2": "^4.0.2",
     "uglify-js": "^3.11.5"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "homepage": "https://github.com/craftzdog/react-native-buffer",
   "jspm": {
     "map": {


### PR DESCRIPTION
Yarn 3 requires upstream peers to be exposed as `peerDependencies` or `dependencies`, installation will generate a warning even if they are in `devDependencies`.

<img width="944" alt="image" src="https://user-images.githubusercontent.com/85772/215678071-fef2a4d6-457a-4bff-aee5-8965ef063235.png">
