### PR TITLE
feat: bump react-native-quick-base64 to support 16kb pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "license": "MIT",
       "dependencies": {
         "ieee754": "^1.2.1",
-        "react-native-quick-base64": "^2.0.5"
+        "react-native-quick-base64": "^2.2.2"
       },
       "devDependencies": {
         "airtap": "^3.0.0",
@@ -11131,13 +11131,13 @@
       }
     },
     "node_modules/react-native-quick-base64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-2.1.2.tgz",
-      "integrity": "sha512-xghaXpWdB0ji8OwYyo0fWezRroNxiNFCNFpGUIyE7+qc4gA/IGWnysIG5L0MbdoORv8FkTKUvfd6yCUN5R2VFA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-2.2.2.tgz",
+      "integrity": "sha512-WLHSifHLoamr2kF00Gov0W9ud6CfPshe1rmqWTquVIi9c62qxOaJCFVDrXFZhEBU8B8PvGLVuOlVKH78yhY0Fg==",
       "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      },
+      "workspaces": [
+        "example"
+      ],
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "ieee754": "^1.2.1",
-    "react-native-quick-base64": "^2.0.5"
+    "react-native-quick-base64": "^2.2.2"
   },
   "devDependencies": {
     "airtap": "^3.0.0",


### PR DESCRIPTION
This pull request updates the dependency `react-native-quick-base64` to version 2.2.2, which includes support for Android 16KB pages.